### PR TITLE
Disable rennovate updates for Github Workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    ".github/workflows/**"
   ]
 }


### PR DESCRIPTION
Disable rennovate updates for Github Workflow dependencies which are in folder `.github/workflows`.